### PR TITLE
Remove dependency on pyqt.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
 
 about:
   home: https://github.com/nion-software/nionui
-  license: Apache Software
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.txt
   summary: Nion UI framework.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 76e21bbad1e3a86ed983efdd9527b061d04c46614bef71627070da06dcd89dcc
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - nionui=nion.ui.command:main
@@ -28,7 +28,6 @@ requirements:
     - nionutils >=0.3.19
     - numpy
     - python >=3.6
-    - pyqt
 
 test:
   imports:


### PR DESCRIPTION
It requires either pyqt or nionswift-tool, but not necessarily one
or the other. In particular, when using nionswift-tool, it is better
to not have to install pyqt.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
